### PR TITLE
fix dog bug

### DIFF
--- a/src/Components/AutomatedBehaviours.hpp
+++ b/src/Components/AutomatedBehaviours.hpp
@@ -43,7 +43,7 @@ public:
 	void wander();
 	
     ///Heading of AI
-	glm::vec3 Heading = glm::vec3(0);
+	glm::vec3 Heading = glm::vec3(0.5f, 0, 0.5f);
 	///angle
 	float Angle = 0;
 	///AI Top speed


### PR DESCRIPTION
 turns out that glm returns nan if you try and normalize a zero vector (assumed it would return 0). This only happens if you (or blake) happen to put a dog down exactly as he sees a pickupable directly ahead of him (nothing to do with the angle in the end). Initializing the direction vector to a 0.5, 0, 0.5 unit vector instead of a 0 vector seems to have resolved it